### PR TITLE
Koto-ls integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.vsix
+out

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # koto-vscode
 
-Syntax highlighting support for the [Koto](https://github.com/koto-lang/koto)
+Language server and syntax highlighting support for the [Koto](https://github.com/koto-lang/koto)
 programming language in [Visual Studio Code](https://code.visualstudio.com).
 
 ## Installation

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -16,7 +16,7 @@
     ["[", "]"],
     ["(", ")"],
     ["|", "|"],
-    ["\"", "\""]
+    ["\"", "\""],
     ["'", "'"]
   ],
   // symbols that can be used to surround a selection

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@types/node": "^24.1.0",
     "@types/vscode": "^1.102.0",
     "@vscode/vsce": "^3.6.0",
-    "typescript": "^5.4.5"
+    "typescript": "~5.4.0"
   },
   "dependencies": {
     "@types/follow-redirects": "^1.14.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
       "properties": {
         "koto.server.path": {
           "type": "string",
-          "default": "koto-ls",
           "description": "Path to the koto-ls executable"
         },
         "koto.server.args": {
@@ -80,6 +79,11 @@
         "command": "koto.restartServer",
         "title": "Restart Language Server",
         "category": "Koto"
+      },
+      {
+        "command": "koto.checkForUpdates",
+        "title": "Check for Language Server Updates",
+        "category": "Koto"
       }
     ]
   },
@@ -90,12 +94,14 @@
     "package": "vsce package"
   },
   "devDependencies": {
-    "@types/vscode": "^1.74.0",
     "@types/node": "16.x",
-    "typescript": "^4.9.4",
-    "@vscode/vsce": "^2.19.0"
+    "@types/vscode": "^1.74.0",
+    "@vscode/vsce": "^2.19.0",
+    "typescript": "^4.9.4"
   },
   "dependencies": {
+    "@types/follow-redirects": "^1.14.4",
+    "follow-redirects": "^1.15.11",
     "vscode-languageclient": "^8.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@types/node": "^24.1.0",
     "@types/vscode": "^1.102.0",
     "@vscode/vsce": "^3.6.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "@types/follow-redirects": "^1.14.4",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,15 @@
   },
   "publisher": "koto-lang",
   "license": "MIT",
+  "keywords": [
+    "koto",
+    "language server",
+    "lsp"
+  ],
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "onLanguage:koto"
+  ],
   "contributes": {
     "languages": [
       {
@@ -35,6 +44,58 @@
         "scopeName": "source.koto",
         "path": "./syntaxes/koto.tmLanguage.json"
       }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Koto Language Server",
+      "properties": {
+        "koto.server.path": {
+          "type": "string",
+          "default": "koto-ls",
+          "description": "Path to the koto-ls executable"
+        },
+        "koto.server.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Arguments to pass to koto-ls"
+        },
+        "koto.trace.server": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the language server."
+        }
+      }
+    },
+    "commands": [
+      {
+        "command": "koto.restartServer",
+        "title": "Restart Language Server",
+        "category": "Koto"
+      }
     ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "package": "vsce package"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.74.0",
+    "@types/node": "16.x",
+    "typescript": "^4.9.4",
+    "@vscode/vsce": "^2.19.0"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^8.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,14 +94,14 @@
     "package": "vsce package"
   },
   "devDependencies": {
-    "@types/node": "16.x",
-    "@types/vscode": "^1.74.0",
-    "@vscode/vsce": "^2.19.0",
-    "typescript": "^4.9.4"
+    "@types/node": "^24.1.0",
+    "@types/vscode": "^1.102.0",
+    "@vscode/vsce": "^3.6.0",
+    "typescript": "^5.9.2"
   },
   "dependencies": {
     "@types/follow-redirects": "^1.14.4",
     "follow-redirects": "^1.15.11",
-    "vscode-languageclient": "^8.1.0"
+    "vscode-languageclient": "^9.0.1"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,9 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { https } from 'follow-redirects';
+import { promisify } from 'util';
+import { exec } from 'child_process';
 import {
     LanguageClient,
     LanguageClientOptions,
@@ -6,48 +11,246 @@ import {
     TransportKind
 } from 'vscode-languageclient/node';
 
+const execAsync = promisify(exec);
+
 let client: LanguageClient;
 
-export function activate(context: vscode.ExtensionContext) {
+interface GitHubRelease {
+    tag_name: string;
+    assets: Array<{
+        name: string;
+        browser_download_url: string;
+    }>;
+}
+
+async function getLatestRelease(): Promise<GitHubRelease> {
+    return new Promise((resolve, reject) => {
+        const options = {
+            hostname: 'api.github.com',
+            path: '/repos/koto-lang/koto-ls/releases/latest',
+            headers: {
+                'User-Agent': 'koto-vscode-extension'
+            }
+        };
+
+        https.get(options, (res) => {
+            let data = '';
+            res.on('data', (chunk) => data += chunk);
+            res.on('end', () => {
+                try {
+                    resolve(JSON.parse(data));
+                } catch (error) {
+                    reject(error);
+                }
+            });
+        }).on('error', reject);
+    });
+}
+
+async function downloadFile(url: string, filePath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const options = {
+            hostname: new URL(url).hostname,
+            path: new URL(url).pathname,
+            headers: {
+                'User-Agent': 'koto-vscode-extension'
+            }
+        };
+
+        const file = fs.createWriteStream(filePath);
+        const request = https.request(options, (response) => {
+            response.pipe(file);
+            file.on('finish', () => {
+                file.close();
+                resolve();
+            });
+        }).on('error', (err) => {
+            fs.unlink(filePath, () => { }); // Delete the file on error
+            reject(err);
+        });
+
+        request.end();
+    });
+}
+
+function getPlatformBinaryName(): string {
+    const platform = process.platform;
+    const arch = process.arch;
+    const key = platform + '-' + arch;
+    const binaryNames: { [key: string]: string } = {
+        'win32-x64': 'koto-ls-x86_64-pc-windows-msvc.zip',
+        'darwin-arm64': 'koto-ls-aarch64-apple-darwin.tar.gz',
+        'darwin-x64': 'koto-ls-x86_64-apple-darwin.tar.gz',
+        'linux-x64': 'koto-ls-x86_64-unknown-linux-gnu.tar.gz'
+    }
+
+    const binaryName = binaryNames[key];
+    if (binaryName)
+        return binaryName;
+
+    throw new Error(`Unsupported platform: ${platform}-${arch}`);
+}
+
+async function extractArchive(archivePath: string, extractDir: string): Promise<string> {
+    const isZip = archivePath.endsWith('.zip');
+    const isTarGz = archivePath.endsWith('.tar.gz');
+
+    if (!isZip && !isTarGz) throw new Error(`Unsupported archive format: ${archivePath}`);
+
+    if (!fs.existsSync(extractDir)) fs.mkdirSync(extractDir, { recursive: true });
+
+    const command = (process.platform === 'win32' && isZip)
+        ? `powershell -command "Expand-Archive -Path '${archivePath}' -DestinationPath '${extractDir}' -Force"`
+        : isTarGz ? `tar -xzf "${archivePath}" -C "${extractDir}"`
+            : null;
+
+    if (!command) throw new Error(`Cannot extract ${archivePath} on ${process.platform}`);
+    await execAsync(command);
+
+    const expectedBinaryName = 'koto-ls' + (process.platform === 'win32' ? '.exe' : '');
+    const findBinary = (dir: string): string | null => {
+        for (const item of fs.readdirSync(dir)) {
+            const itemPath = path.join(dir, item);
+            const stat = fs.statSync(itemPath);
+            if (stat.isFile() && item === expectedBinaryName) return itemPath;
+            if (stat.isDirectory()) {
+                const found = findBinary(itemPath);
+                if (found) return found;
+            }
+        }
+        return null;
+    };
+
+    const binaryPath = findBinary(extractDir);
+    if (!binaryPath) throw new Error(`Could not find ${expectedBinaryName} in extracted archive`);
+    return binaryPath;
+}
+
+async function getStoredVersion(versionFilePath: string): Promise<string | null> {
+    try {
+        return fs.existsSync(versionFilePath) ? fs.readFileSync(versionFilePath, 'utf8').trim() : null;
+    } catch {
+        return null;
+    }
+}
+
+async function isValidBinary(binaryPath: string): Promise<boolean> {
+    return fs.existsSync(binaryPath);
+}
+
+async function downloadAndExtract(context: vscode.ExtensionContext, release: GitHubRelease): Promise<void> {
+    const binaryName = getPlatformBinaryName();
+    const asset = release.assets.find(a => a.name === binaryName);
+
+    if (!asset) {
+        throw new Error(`No binary found, expecting: ${binaryName}`);
+    }
+
+    const storageDir = context.globalStorageUri.fsPath;
+    const archivePath = path.join(storageDir, binaryName);
+    const extractDir = path.join(storageDir, 'extracted');
+    const extensionBinaryPath = getBinaryPath(context);
+
+    // Ensure storage directory exists
+    if (!fs.existsSync(storageDir)) {
+        fs.mkdirSync(storageDir, { recursive: true });
+    }
+
+    // Download and extract
+    await downloadFile(asset.browser_download_url, archivePath);
+    const extractedBinaryPath = await extractArchive(archivePath, extractDir);
+
+    // Install binary
+    fs.copyFileSync(extractedBinaryPath, extensionBinaryPath);
+    if (process.platform !== 'win32') {
+        fs.chmodSync(extensionBinaryPath, '755');
+    }
+
+    // Store version and cleanup
+    fs.writeFileSync(path.join(storageDir, 'version.txt'), release.tag_name);
+    fs.unlinkSync(archivePath);
+    fs.rmSync(extractDir, { recursive: true, force: true });
+}
+
+async function ensureKotoLs(context: vscode.ExtensionContext, serverPath: string): Promise<string> {
+    const extensionBinaryPath = getBinaryPath(context);
+
+    // skip if user use a custom path for koto-ls
+    if (serverPath) {
+        return serverPath;
+    }
+
+    const versionFilePath = path.join(context.globalStorageUri.fsPath, 'version.txt');
+
+    const currentVersion = await getStoredVersion(versionFilePath);
+    const release = await getLatestRelease();
+
+    // Check if current installation is up to date
+    if (currentVersion && await isValidBinary(extensionBinaryPath)) {
+        if (currentVersion === release.tag_name) {
+            return extensionBinaryPath;
+        }
+        vscode.window.showInformationMessage(`Updating koto-ls from ${currentVersion} to ${release.tag_name}`);
+    } else {
+        vscode.window.showInformationMessage('Downloading koto-ls language server...');
+    }
+
+    try {
+        await downloadAndExtract(context, release);
+        vscode.window.showInformationMessage(`Downloaded koto-ls ${release.tag_name} successfully!`);
+        return extensionBinaryPath;
+    } catch (error) {
+        vscode.window.showErrorMessage(`Failed to download koto-ls: ${error}`);
+        throw error;
+    }
+}
+
+function getBinaryPath(context: vscode.ExtensionContext): string {
+    return path.join(context.globalStorageUri.fsPath, 'koto-ls' + (process.platform === 'win32' ? '.exe' : ''));
+}
+
+export async function activate(context: vscode.ExtensionContext) {
     const config = vscode.workspace.getConfiguration('koto');
-    const serverPath = config.get<string>('server.path', 'koto-ls');
+    let configuredServerPath = config.get<string>('server.path', '');
     const serverArgs = config.get<string[]>('server.args', []);
 
-    const serverOptions: ServerOptions = {
-        run: {
-            command: serverPath,
-            args: serverArgs,
-            transport: TransportKind.stdio,
-        },
-        debug: {
-            command: serverPath,
-            args: serverArgs,
-            transport: TransportKind.stdio,
-        }
-    };
+    try {
+        const serverPath = await ensureKotoLs(context, configuredServerPath);
+        const serverOptions: ServerOptions = {
+            run: {
+                command: serverPath,
+                args: serverArgs,
+                transport: TransportKind.stdio,
+            },
+            debug: {
+                command: serverPath,
+                args: serverArgs,
+                transport: TransportKind.stdio,
+            }
+        };
 
-    const clientOptions: LanguageClientOptions = {
-        documentSelector: [
-            { scheme: 'file', language: 'koto' }
-        ],
-        synchronize: {
-            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.koto')
-        },
-    };
+        const clientOptions: LanguageClientOptions = {
+            documentSelector: [
+                { scheme: 'file', language: 'koto' }
+            ],
+            synchronize: {
+                fileEvents: vscode.workspace.createFileSystemWatcher('**/*.koto')
+            },
+        };
 
-    client = new LanguageClient(
-        'koto-language-server',
-        'Koto Language Server',
-        serverOptions,
-        clientOptions
-    );
+        client = new LanguageClient(
+            'koto-language-server',
+            'Koto Language Server',
+            serverOptions,
+            clientOptions
+        );
 
-    client.start();
-    context.subscriptions.push(client);
+        client.start();
+        context.subscriptions.push(client);
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand('koto.restartServer', async () => {
-            if (client) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand('koto.restartServer', async () => {
+                if (!client) return;
                 try {
                     await client.stop();
                     await client.start();
@@ -55,9 +258,11 @@ export function activate(context: vscode.ExtensionContext) {
                 } catch (error) {
                     vscode.window.showErrorMessage(`Failed to restart server: ${error}`);
                 }
-            }
-        })
-    );
+            }),
+        );
+    } catch (error) {
+        vscode.window.showErrorMessage(`Failed to start Koto Language Server: ${error}`);
+    }
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,69 @@
+import * as vscode from 'vscode';
+import {
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    TransportKind
+} from 'vscode-languageclient/node';
+
+let client: LanguageClient;
+
+export function activate(context: vscode.ExtensionContext) {
+    const config = vscode.workspace.getConfiguration('koto');
+    const serverPath = config.get<string>('server.path', 'koto-ls');
+    const serverArgs = config.get<string[]>('server.args', []);
+
+    const serverOptions: ServerOptions = {
+        run: {
+            command: serverPath,
+            args: serverArgs,
+            transport: TransportKind.stdio,
+        },
+        debug: {
+            command: serverPath,
+            args: serverArgs,
+            transport: TransportKind.stdio,
+        }
+    };
+
+    const clientOptions: LanguageClientOptions = {
+        documentSelector: [
+            { scheme: 'file', language: 'koto' }
+        ],
+        synchronize: {
+            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.koto')
+        },
+    };
+
+    client = new LanguageClient(
+        'koto-language-server',
+        'Koto Language Server',
+        serverOptions,
+        clientOptions
+    );
+
+    client.start();
+    context.subscriptions.push(client);
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('koto.restartServer', async () => {
+            if (client) {
+                try {
+                    await client.stop();
+                    await client.start();
+                    vscode.window.showInformationMessage('Koto Language Server restarted');
+                } catch (error) {
+                    vscode.window.showErrorMessage(`Failed to restart server: ${error}`);
+                }
+            }
+        })
+    );
+}
+
+export function deactivate(): Thenable<void> | undefined {
+    if (!client) {
+        return undefined;
+    }
+
+    return client.stop();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "ES2020",
+        "outDir": "out",
+        "lib": [
+            "ES2020"
+        ],
+        "sourceMap": true,
+        "rootDir": "src",
+        "strict": true
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "ES2020",
+        "target": "es2020",
         "outDir": "out",
         "lib": [
-            "ES2020"
+            "es2020"
         ],
         "sourceMap": true,
         "rootDir": "src",


### PR DESCRIPTION
This PR add support for koto-ls as the language server for all `*.koto` files.
At startup Koto-ls will be download or updated, a custom executable path can be provided in the settings.

Thanks to this fix koto-lang/koto-ls@38fd0fc456bb2eb67494fe1a4d3a51388cc2a7e3 , works perfectly fine now.

----

Not really usable for now, koto-ls never close the stdin when vscode call the `exit` method on the server.
And since vscode doesn't close it either, it hangs until it times out.

### Reproduce
- Open the extension project, open the `src/extension.ts` file.
- Press F5 to launch the extension in another vscode instance.
- Create a new `.koto` file, and write some Koto code.
- The editor should quickly tell you the koto language server is erroring.
- Open Output (View -> Output), select `Koto Language Server` to get logs.

In order to debug `koto-ls`, i just modify `koto-ls` code and use this command `cargo install --path .` to install my `koto-ls` custom build locally.

### Simpler Test
We can do a more convenient test (in the `koto-ls` project) using this command `(printf 'Content-Length: 33\r\n\r\n{"jsonrpc":"2.0","method":"exit"}' && cat) | cargo run` but i'm not sure the LSP spec let us to do that without a `shutdown` or other calls before.
