### PR TITLE
Fix function parameter highlighting

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -7,8 +7,7 @@
   "brackets": [
     ["{", "}"],
     ["[", "]"],
-    ["(", ")"],
-    ["|", "|"]
+    ["(", ")"]
   ],
   // symbols that are auto closed when typing
   "autoClosingPairs": [

--- a/syntaxes/koto.tmLanguage.json
+++ b/syntaxes/koto.tmLanguage.json
@@ -338,7 +338,7 @@
           "begin": "\\|",
           "beginCaptures": {
             "0": {
-              "name": "keyword.other.function-definition.koto"
+              "name": "punctuation.definition.arguments.start.koto"
             }
           },
           "end": "(\\|)(\\s*(->)\\s*([[:alpha:]_][[:alnum:]_]*\\??))?",


### PR DESCRIPTION
It looks like vscode can't handle "brackets" where the begin and end are the same character. Currently function parameters look like this: 
<img width="347" height="123" alt="Screenshot from 2025-10-17 18-54-14" src="https://github.com/user-attachments/assets/690405e7-ede8-4961-9454-daca7855cf1a" />
Showing the error color, presumably because it doesn't see the "|" as a closing delimiter.

After removing the "brackets" entry it looks like this: 
<img width="388" height="126" alt="Screenshot from 2025-10-17 18-55-30" src="https://github.com/user-attachments/assets/386bba46-3cfe-4c57-a0ba-e33dc58b4a82" />

The starting pipe is marked as a "keyword" which i assume is some holdover of a previous design. I've changed it to a "punctuation" just like the end pipe, so now the parameters look like this:
<img width="388" height="126" alt="Screenshot from 2025-10-17 18-57-07" src="https://github.com/user-attachments/assets/0b187c4b-2285-466e-9079-d64c5a4f836f" />
