### PR TITLE
Fix line comment highlighting

### DIFF
--- a/syntaxes/koto.tmLanguage.json
+++ b/syntaxes/koto.tmLanguage.json
@@ -14,7 +14,7 @@
           "include": "#comment-block"
         },
         {
-          "name": "keyword.comment.line.koto",
+          "name": "comment.line.koto",
           "match": "#.*"
         },
         {


### PR DESCRIPTION
The line comments were being highlighted as a "keyword" instead of a "comment".

Before:
<img width="192" height="53" alt="Screenshot from 2025-10-17 19-09-02" src="https://github.com/user-attachments/assets/9ac365ca-a239-484a-a09b-db90c0eb89e2" />

After:
<img width="192" height="53" alt="Screenshot from 2025-10-17 19-07-38" src="https://github.com/user-attachments/assets/1f779b14-fec0-498d-abc7-f8b96c25b6a1" />

